### PR TITLE
Support Amazon EC2 generated Administrator passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.9.2 / 2015-01-27
+### New features
+* Adding support for AWS Private Key Pair from TeamCity through AWS_PRIVATE_KEY Environment variable
+
+## 0.9.1 / 2015-01-20
+### New features
+* Supports Amazon generated Windows Password
+* Improved WinRm provisioning through user_data
+
+
 ## 0.8.0 / 2014-02-11
 
 ### Bug fixes

--- a/data/amis.json
+++ b/data/amis.json
@@ -5,66 +5,100 @@
       "ubuntu-12.04": "ami-bb9a08ba",
       "ubuntu-12.10": "ami-4556c544",
       "ubuntu-13.04": "ami-97099a96",
+      "ubuntu-13.10": "ami-45f1a744",
+      "ubuntu-14.04": "ami-955c0c94",
       "centos-6.4": "ami-9ffa709e",
-      "debian-7.1.0": "ami-f1f064f0"
+      "debian-7.1.0": "ami-f1f064f0",
+      "windows-2012r2": "ami-b67e73b7",
+      "windows-2008r2": "ami-e67e73e7"
+
     },
     "ap-southeast-1": {
       "ubuntu-10.04": "ami-34713866",
       "ubuntu-12.04": "ami-881c57da",
       "ubuntu-12.10": "ami-3ce0a86e",
       "ubuntu-13.04": "ami-4af5bd18",
+      "ubuntu-13.10": "ami-02e6b850",
+      "ubuntu-14.04": "ami-9a7c25c8",
       "centos-6.4": "ami-46f5bb14",
-      "debian-7.1.0": "ami-fe8ac3ac"
+      "debian-7.1.0": "ami-fe8ac3ac",
+      "windows-2012r2": "ami-91f4d8c3",
+      "windows-2008r2": "ami-b9f4d8eb"
     },
     "ap-southeast-2": {
       "ubuntu-10.04": "ami-2f009315",
       "ubuntu-12.04": "ami-cb26b4f1",
       "ubuntu-12.10": "ami-1703912d",
       "ubuntu-13.04": "ami-8f32a0b5",
+      "ubuntu-13.10": "ami-e54423df",
+      "ubuntu-14.04": "ami-f3b1d6c9",
       "centos-6.4": "ami-9352c1a9",
-      "debian-7.1.0": "ami-4e099a74"
+      "debian-7.1.0": "ami-4e099a74",
+      "windows-2012r2": "ami-356d050f",
+      "windows-2008r2": "ami-096d0533"
     },
     "eu-west-1": {
       "ubuntu-10.04": "ami-bbadb0cf",
       "ubuntu-12.04": "ami-d3b5aea7",
       "ubuntu-12.10": "ami-6b62791f",
       "ubuntu-13.04": "ami-6fd4cf1b",
+      "ubuntu-13.10": "ami-39eb3f4e",
+      "ubuntu-14.04": "ami-c112c5b6",
       "centos-6.4": "ami-75190b01",
-      "debian-7.1.0": "ami-954559e1"
+      "debian-7.1.0": "ami-954559e1",
+      "windows-2012r2": "ami-1e03bf69",
+      "windows-2008r2": "ami-c003bfb7"
+
     },
     "sa-east-1": {
       "ubuntu-10.04": "ami-962c898b",
       "ubuntu-12.04": "ami-c905a1d4",
       "ubuntu-12.10": "ami-e759fdfa",
       "ubuntu-13.04": "ami-4b2b8f56",
+      "ubuntu-13.10": "ami-076cc21a",
+      "ubuntu-14.04": "ami-052b8518",
       "centos-6.4": "ami-a665c0bb",
-      "debian-7.1.0": "ami-b03590ad"
+      "debian-7.1.0": "ami-b03590ad",
+      "windows-2012r2": "ami-017ccc1c",
+      "windows-2008r2": "ami-5d7ccc40"
+
     },
     "us-east-1": {
       "ubuntu-10.04": "ami-1ab3ce73",
       "ubuntu-12.04": "ami-2f115c46",
       "ubuntu-12.10": "ami-4d5b1824",
       "ubuntu-13.04": "ami-a73371ce",
+      "ubuntu-13.10": "ami-a65393ce",
+      "ubuntu-14.04": "ami-4a915c22",
       "centos-6.4": "ami-bf5021d6",
       "debian-7.1.0": "ami-50d9a439",
-      "windows-2008R2": "ami-2ae02342",
-      "windows-2012R2": "ami-9ade1df2"
+      "windows-2012r2": "ami-c4fe9aac",
+      "windows-2008r2": "ami-f8ff9b90"
     },
     "us-west-1": {
       "ubuntu-10.04": "ami-848ba2c1",
       "ubuntu-12.04": "ami-eaf0daaf",
       "ubuntu-12.10": "ami-02220847",
       "ubuntu-13.04": "ami-fe052fbb",
+      "ubuntu-13.10": "ami-bb2a2afe",
+      "ubuntu-14.04": "ami-d99a9a9c",
       "centos-6.4": "ami-5d456c18",
-      "debian-7.1.0": "ami-1a9bb25f"
+      "debian-7.1.0": "ami-1a9bb25f",
+      "windows-2012r2": "ami-cfa5b68a",
+      "windows-2008r2": "ami-8ba5b6ce"
     },
     "us-west-2": {
       "ubuntu-10.04": "ami-f19407c1",
       "ubuntu-12.04": "ami-e6f36fd6",
       "ubuntu-12.10": "ami-0c069b3c",
       "ubuntu-13.04": "ami-4ade427a",
+      "ubuntu-13.10": "ami-c18ff1f1",
+      "ubuntu-14.04": "ami-b7720b87",
       "centos-6.4": "ami-b3bf2f83",
-      "debian-7.1.0": "ami-158a1925"
+      "debian-7.1.0": "ami-158a1925",
+      "windows-2012r2": "ami-29d18719",
+      "windows-2008r2": "ami-57d18767"
+
     }
   },
   "usernames": {
@@ -72,14 +106,12 @@
     "ubuntu-12.04": "ubuntu",
     "ubuntu-12.10": "ubuntu",
     "ubuntu-13.04": "ubuntu",
+    "ubuntu-13.10": "ubuntu",
+    "ubuntu-14.04": "ubuntu",
     "centos-6.4": "root",
     "debian-7.1.0": "admin",
-    "windows-2008R2": "chef",
-    "windows-2012R2": "chef"
-  },
-  "passwords": {
-    "windows-2008R2": "chef",
-    "windows-2012R2": "chef"
+    "windows-2008r2": "administrator",
+    "windows-2012r2": "administrator"
   },
   "references": {
     "ubuntu": "http://uec-images.ubuntu.com/query/",

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = '0.8.1.dev'
+    EC2_VERSION = '0.9.1.dev'
   end
 end

--- a/lib/kitchen/driver/ec2_version.rb
+++ b/lib/kitchen/driver/ec2_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for EC2 Test Kitchen driver
-    EC2_VERSION = '0.9.1.dev'
+    EC2_VERSION = '0.9.2.dev'
   end
 end


### PR DESCRIPTION
Hi Salim,

Thank you for your great work on enabling test-kitchen and kitchen-ec2 to work with Windows through WinRm and Amazon EC2!
Our idea was to bring your original solution one step further to make it more similar/simple as with Linux. With my additions, we don't need to inject static Admin user and password, but it uses the Amazon EC2 randomly generated Administrator passwords to establish connection to the Windows instances.

Benefits in addition to your kitchen-ec2 library:
- deprecates the less secure static/default admin passwords (but still supports it if its needed)
- no need for weakening PasswordComplexity security policy in Windows
- uses the Linux SSH friendly SSH_KEY config attribute to decrypt windows passwords, no extra configuration needed
- improved logging for WinRm provisioning from user_data to Amazon's EC2Config folder
- added Windows Server 2008 R2 and Server 2012 R2 base images for every region
- backward compatible with your original kitchen-ec2 library
- fully supports automated tests execution from CI systems

Thank you for considering my pull request and really looking forward for your suggestions.

Thanks and Regards,
Akos
